### PR TITLE
Update config.py

### DIFF
--- a/libs/config.py
+++ b/libs/config.py
@@ -4,7 +4,7 @@ from easydict import EasyDict
 
 def load_config(filepath):
     with open(filepath, mode='r',encoding='utf-8') as f:
-        cfg = yaml.load(f.read())
+        cfg = yaml.load(f.read(),Loader=yaml.FullLoader)
         cfg = EasyDict(cfg)
 
     check_fraction(cfg.noise, 'noise')


### PR DESCRIPTION
old style,YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe.