### PR TITLE
Removed filter word less than 2 characters, fixed img.shape in noiser

### DIFF
--- a/textrenderer/corpus/eng_corpus.py
+++ b/textrenderer/corpus/eng_corpus.py
@@ -21,7 +21,7 @@ class EngCorpus(Corpus):
                     word = word.strip()
                     word = ''.join(filter(lambda x: x in self.charsets, word))
 
-                    if word != u'' and len(word) > 2:
+                    if word != u'':
                         self.corpus.append(word)
             print("Word count {}".format(len(self.corpus)))
 

--- a/textrenderer/noiser.py
+++ b/textrenderer/noiser.py
@@ -41,11 +41,9 @@ class Noiser(object):
         """
         Gaussian-distributed additive noise.
         """
-        row, col, channel = img.shape
-
         mean = 0
         stddev = np.sqrt(15)
-        gauss_noise = np.zeros((row, col, channel))
+        gauss_noise = np.zeros(img.shape)
         cv2.randn(gauss_noise, mean, stddev)
         out = img + gauss_noise
 
@@ -55,10 +53,10 @@ class Noiser(object):
         """
         Apply zero-mean uniform noise
         """
-        row, col, channel = img.shape
+        imshape = img.shape
         alpha = 0.05
-        gauss = np.random.uniform(0 - alpha, alpha, (row, col, channel))
-        gauss = gauss.reshape(row, col, channel)
+        gauss = np.random.uniform(0 - alpha, alpha, imshape)
+        gauss = gauss.reshape(*imshape)
         out = img + img * gauss
         return out
 
@@ -66,7 +64,6 @@ class Noiser(object):
         """
         Salt and pepper noise. Replaces random pixels with 0 or 255.
         """
-        row, col, channel = img.shape
         s_vs_p = 0.5
         amount = np.random.uniform(0.004, 0.01)
         out = np.copy(img)


### PR DESCRIPTION
Fixed filter out word less than 2 characters in eng corpus in https://github.com/Sanster/text_renderer/issues/2
Fixed shape in https://github.com/Sanster/text_renderer/issues/77