### PR TITLE
Modify code to avoid numpy warning

### DIFF
--- a/textrenderer/noiser.py
+++ b/textrenderer/noiser.py
@@ -71,13 +71,13 @@ class Noiser(object):
         num_salt = np.ceil(amount * img.size * s_vs_p)
         coords = [np.random.randint(0, i - 1, int(num_salt))
                   for i in img.shape]
-        out[coords] = 255.
+        out[tuple(coords)] = 255.
 
         # Pepper mode
         num_pepper = np.ceil(amount * img.size * (1. - s_vs_p))
         coords = [np.random.randint(0, i - 1, int(num_pepper))
                   for i in img.shape]
-        out[coords] = 0
+        out[tuple(coords)] = 0
         return out
 
     def apply_poisson_noise(self, img):


### PR DESCRIPTION
It showed warning `FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use arr[tuple(seq)] instead of arr[seq]. In the future this will be interpreted as an array index, arr[np.array(seq)], which will result either in an error or a different result.`.