### PR TITLE
Provide better GPU building support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ libs/gpu/build/
 output/
 .caches
 
+libs/gpu/.setuptools-cmake-build
+libs/gpu/CMakeLists.txt

--- a/README.md
+++ b/README.md
@@ -78,94 +78,9 @@ chars not supported(4971):
 ```
 
 # Generate image using GPU
-If you want to use GPU to make generate image faster, first compile OpenCV 3.x with CUDA (OpenCV 4.x won't work) and Python suport.
+If you want to use GPU to make generate image faster, first compile OpenCV 3.x with CUDA (OpenCV 4.x won't work), opencv contrib, and Python suport.
 
-For example, OpenCV 3.4.11 with Python 3.8.1(via Miniconda) with NVIDIA GTX 1080Ti on Ubuntu 20.04:
-
-```bash
-# opencv-3.4.11
-cd ~/work;
-git clone https://gitee.com/mirros/opencv opencv-3.4.11
-cd opencv-3.4.11
-git checkout -b 3.4.11 3.4.11
-
-# opencv_contrib-3.4.11
-cd ..
-git clone https://gitee.com/mirrors/opencv_contrib opencv_contrib-3.4.11
-cd opencv_contrib-3.4.11
-git checkout -b 3.4.11 3.4.11
-
-# nvidia card compute capability
-cd ..
-git clone https://github.com/zchrissirhcz/check_ComputeCapability
-cd check_ComputeCapability
-make
-./check_cc
-
-# prepare compile script
-cd ../opencv-3.4.11
-vim compile.sh
-```
-
-`compile.sh`'s content:
-```bash
-#!/bin/bash
-
-set -x
-set -e
-
-mkdir -p $HOME/soft
-
-rm -rf build
-mkdir -p build
-cd build
-
-LOG="../cmake.log"
-touch $LOG
-rm $LOG
-
-exec &> >(tee -a "$LOG")
-
-cmake .. \
-    -D CMAKE_BUILD_TYPE=Release \
-    -D CMAKE_INSTALL_PREFIX=$HOME/soft/opencv-3.4.11 \
-    -D WITH_CUDA=ON \
-    -D CUDA_ARCH_BIN=6.1 \
-    -D OPENCV_EXTRA_MODULES_PATH=$HOME/work/opencv_contrib-3.4.11/modules \
-    -D INSTALL_PYTHON_EXAMPLES=ON \
-    -D OPENCV_PYTHON3_VERSION=3.8 \
-    -D PYTHON3_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
-    -D PYTHON3_INCLUDE_DIR=$HOME/soft/miniconda3/include/python3.8 \
-    -D PYTHON3_LIBRARY=$HOME/soft/miniconda3/lib/libpython3.8.so \
-    -D BUILD_opencv_python3=ON \
-    -D BUILD_opencv_python2=OFF \
-    -D PYTHON_DEFAULT_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
-    -D HAVE_opencv_python3=ON \
-    -D BUILD_TIFF=ON \
-    -D WITH_VTK=OFF \
-    -D WITH_MATLAB=OFF \
-    -D BUILD_DOCS=OFF \
-
-make -j4
-make install
-```
-
-Then do:
-```bash
-# compile opencv
-./compile.sh
-
-# compile cython module
-cd libs/gpu
-python setup.py build_ext --inplace
-```
-
-Finally, and add `--gpu` option when run `main.py`
-
-refs: 
-- [Accessing OpenCV CUDA Functions from Python (No PyCUDA)](https://stackoverflow.com/questions/42125084/accessing-opencv-cuda-functions-from-python-no-pycuda)
-- [Compiling OpenCV with CUDA support](https://www.pyimagesearch.com/2016/07/11/compiling-opencv-with-cuda-support/)
-
+See [build-gpu-libs.md](build-gpu-libs.md) for more details.
 
 # Debug mode
 Run `python3 main.py --debug` will save images with extract information.

--- a/README.md
+++ b/README.md
@@ -78,14 +78,94 @@ chars not supported(4971):
 ```
 
 # Generate image using GPU
-If you want to use GPU to make generate image faster, first compile opencv with CUDA.
-[Compiling OpenCV with CUDA support](https://www.pyimagesearch.com/2016/07/11/compiling-opencv-with-cuda-support/)
+If you want to use GPU to make generate image faster, first compile OpenCV 3.x with CUDA (OpenCV 4.x won't work) and Python suport.
 
-Then build Cython part, and add `--gpu` option when run `main.py`
+For example, OpenCV 3.4.11 with Python 3.8.1(via Miniconda) with NVIDIA GTX 1080Ti on Ubuntu 20.04:
+
+```bash
+# opencv-3.4.11
+cd ~/work;
+git clone https://gitee.com/mirros/opencv opencv-3.4.11
+cd opencv-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# opencv_contrib-3.4.11
+cd ..
+git clone https://gitee.com/mirrors/opencv_contrib opencv_contrib-3.4.11
+cd opencv_contrib-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# nvidia card compute capability
+cd ..
+git clone https://github.com/zchrissirhcz/check_ComputeCapability
+cd check_ComputeCapability
+make
+./check_cc
+
+# prepare compile script
+cd ../opencv-3.4.11
+vim compile.sh
 ```
+
+`compile.sh`'s content:
+```bash
+#!/bin/bash
+
+set -x
+set -e
+
+mkdir -p $HOME/soft
+
+rm -rf build
+mkdir -p build
+cd build
+
+LOG="../cmake.log"
+touch $LOG
+rm $LOG
+
+exec &> >(tee -a "$LOG")
+
+cmake .. \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=$HOME/soft/opencv-3.4.11 \
+    -D WITH_CUDA=ON \
+    -D CUDA_ARCH_BIN=6.1 \
+    -D OPENCV_EXTRA_MODULES_PATH=$HOME/work/opencv_contrib-3.4.11/modules \
+    -D INSTALL_PYTHON_EXAMPLES=ON \
+    -D OPENCV_PYTHON3_VERSION=3.8 \
+    -D PYTHON3_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
+    -D PYTHON3_INCLUDE_DIR=$HOME/soft/miniconda3/include/python3.8 \
+    -D PYTHON3_LIBRARY=$HOME/soft/miniconda3/lib/libpython3.8.so \
+    -D BUILD_opencv_python3=ON \
+    -D BUILD_opencv_python2=OFF \
+    -D PYTHON_DEFAULT_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
+    -D HAVE_opencv_python3=ON \
+    -D BUILD_TIFF=ON \
+    -D WITH_VTK=OFF \
+    -D WITH_MATLAB=OFF \
+    -D BUILD_DOCS=OFF \
+
+make -j4
+make install
+```
+
+Then do:
+```bash
+# compile opencv
+./compile.sh
+
+# compile cython module
 cd libs/gpu
-python3 setup.py build_ext --inplace
+python setup.py build_ext --inplace
 ```
+
+Finally, and add `--gpu` option when run `main.py`
+
+refs: 
+- [Accessing OpenCV CUDA Functions from Python (No PyCUDA)](https://stackoverflow.com/questions/42125084/accessing-opencv-cuda-functions-from-python-no-pycuda)
+- [Compiling OpenCV with CUDA support](https://www.pyimagesearch.com/2016/07/11/compiling-opencv-with-cuda-support/)
+
 
 # Debug mode
 Run `python3 main.py --debug` will save images with extract information.

--- a/build-gpu-libs.md
+++ b/build-gpu-libs.md
@@ -105,6 +105,9 @@ git clone https://github.com/zchrissirhcz/text_renderer
 cd text_renderder
 cd libs
 cd gpu
+
+# Let's make sure VS2017 will be called, instead of other version of VS if there's multiple
+call "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat" amd64
 python setup.py build_ext --inplace
 ```
 

--- a/build-gpu-libs.md
+++ b/build-gpu-libs.md
@@ -1,0 +1,211 @@
+## Build libs with GPU support
+
+>By Zhuo Zhang  
+>2020-07-26 17:37:01  
+>https://github.com/zchrissirhcz  
+
+
+We can build `libs` folder with GPU support, which binds OpenCV 3.x's CUDA API calls with provided glue codes.
+
+### Practice1: Windows 10
+For example, OpenCV 3.4.11 with Python 3.7.4(via Miniconda) with NVIDIA GTX 1080Ti on Windows 10:
+
+CUDA version is 11.0, but other versions will be OK.
+
+Visual Studio 2017 version is 15.9.25, other versions not tested.
+
+Assuming Python installed via Anaconda/Miniconda and its version is 3.7.4, other versions not tested.
+
+
+In git bash, do the following:
+```bash
+mkdir -p D:/work
+cd work
+
+# opencv-3.4.11
+cd ~/work;
+git clone https://gitee.com/mirros/opencv opencv-3.4.11
+cd opencv-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# opencv_contrib-3.4.11
+cd ..
+git clone https://gitee.com/mirrors/opencv_contrib opencv_contrib-3.4.11
+cd opencv_contrib-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# nvidia card compute capability
+cd ..
+git clone https://github.com/zchrissirhcz/check_ComputeCapability
+cd check_ComputeCapability
+make
+./check_cc
+
+# prepare compile script
+cd ../opencv-3.4.11
+mkdir -p build
+cd build
+notepad++ vs2017-x64-gpu.bat
+```
+
+`build/vs2017-x64-gpu.bat`'s content:
+```batch
+@echo off
+
+set BUILD_DIR=vs2017-x64-gpu-cuda11
+
+if not exist %BUILD_DIR% md %BUILD_DIR%
+
+cd %BUILD_DIR%
+
+cmake -G "Visual Studio 15 2017 Win64" ^
+    -D CMAKE_BUILD_TYPE=Release ^
+    -D CUDA_TOOLKIT_ROOT_DIR="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.0" ^
+    -D CMAKE_INSTALL_PREFIX=D:/lib/opencv/3.4.11 ^
+    -D OPENCV_EXTRA_MODULES_PATH=D:/work/opencv_contrib-3.4.11/modules ^
+    -D WITH_CUDA=ON ^
+    -D CUDA_ARCH_BIN=6.1 ^
+    -D WITH_VTK=OFF ^
+    -D WITH_MATLAB=OFF ^
+    -D BUILD_DOCS=OFF ^
+    -D BUILD_opencv_python3=ON ^
+    -D BUILD_opencv_python2=OFF ^
+    -D PYTHON3_EXECUTABLE=D:/soft/Miniconda3/python.exe ^
+    -D PYTHON_INCLUDE_DIR=D:/soft/Miniconda3/include ^
+    -D PYTHON_LIBRARY=D:/soft/Miniconda3/libs/python37.lib ^
+    -D WITH_FFMPEG=OFF ^
+    -D BUILD_JAVA=OFF ^
+    -D WITH_PROTOBUF=OFF ^
+    -D WITH_IPP=OFF ^
+    -D BUILD_TESTS=OFF ^
+    -D BUILD_PERF_TESTS=OFF ^
+    -D WITH_OPENCL=OFF ^
+    ../..
+
+cd ..
+
+pause
+```
+
+Then, open a cmd, do these:
+```batch
+D:
+cd D:/work/opencv-3.4.11/build
+run vs2017-x64-gpu.bat
+```
+
+Then open `D:/work/opencv-3.4.11/build/vs2017-x64-gpu/opencv.sln` with Visual Studio 2017, switch to **Release** mode, choose **INSTALL** target and build it.
+
+Later, open another cmd, do the following:
+```bash
+# get text_renderer's code
+D:
+cd D:/work
+git clone https://github.com/zchrissirhcz/text_renderer
+cd text_renderder
+cd libs
+cd gpu
+python setup.py build_ext --inplace
+```
+
+Finally, use the compiled OpenCV Python lib and GpuWrapper lib together, i.e. in `math_utils.py`, modify the imports to be like this:
+```Python
+import sys
+sys.path.insert(1, 'D:/work/opencv-3.4.11/build/vs2017-x64-gpu-cuda11/python_loader')
+import cv2
+import GpuWrapper
+```
+
+And add `--gpu` option when run `main.py`
+
+
+### Practice2: Ubuntu
+For example, OpenCV 3.4.11 with Python 3.8.1(via Miniconda) with NVIDIA GTX 1080Ti on Ubuntu 20.04:
+
+```bash
+# opencv-3.4.11
+cd ~/work;
+git clone https://gitee.com/mirros/opencv opencv-3.4.11
+cd opencv-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# opencv_contrib-3.4.11
+cd ..
+git clone https://gitee.com/mirrors/opencv_contrib opencv_contrib-3.4.11
+cd opencv_contrib-3.4.11
+git checkout -b 3.4.11 3.4.11
+
+# nvidia card compute capability
+cd ..
+git clone https://github.com/zchrissirhcz/check_ComputeCapability
+cd check_ComputeCapability
+make
+./check_cc
+
+# prepare compile script
+cd ../opencv-3.4.11
+vim compile.sh
+```
+
+`compile.sh`'s content:
+```bash
+#!/bin/bash
+
+set -x
+set -e
+
+mkdir -p $HOME/soft
+
+rm -rf build
+mkdir -p build
+cd build
+
+LOG="../cmake.log"
+touch $LOG
+rm $LOG
+
+exec &> >(tee -a "$LOG")
+
+cmake .. \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=$HOME/soft/opencv-3.4.11 \
+    -D WITH_CUDA=ON \
+    -D CUDA_ARCH_BIN=6.1 \
+    -D OPENCV_EXTRA_MODULES_PATH=$HOME/work/opencv_contrib-3.4.11/modules \
+    -D INSTALL_PYTHON_EXAMPLES=ON \
+    -D OPENCV_PYTHON3_VERSION=3.8 \
+    -D PYTHON3_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
+    -D PYTHON3_INCLUDE_DIR=$HOME/soft/miniconda3/include/python3.8 \
+    -D PYTHON3_LIBRARY=$HOME/soft/miniconda3/lib/libpython3.8.so \
+    -D BUILD_opencv_python3=ON \
+    -D BUILD_opencv_python2=OFF \
+    -D PYTHON_DEFAULT_EXECUTABLE=$HOME/soft/miniconda3/bin/python \
+    -D HAVE_opencv_python3=ON \
+    -D BUILD_TIFF=ON \
+    -D WITH_VTK=OFF \
+    -D WITH_MATLAB=OFF \
+    -D BUILD_DOCS=OFF \
+
+make -j4
+make install
+```
+
+Then do:
+```bash
+# compile opencv
+./compile.sh
+
+# compile cython module
+cd libs/gpu
+python setup.py build_ext --inplace
+```
+
+Then use this built opencv2 python library and GpuWrapper together, such as in `math_utils.py`. Modify its imports like in the windows example.
+
+Finally, and add `--gpu` option when run `main.py`
+
+### References
+- [Accessing OpenCV CUDA Functions from Python (No PyCUDA)](https://stackoverflow.com/questions/42125084/accessing-opencv-cuda-functions-from-python-no-pycuda)
+
+- [Compiling OpenCV with CUDA support](https://www.pyimagesearch.com/2016/07/11/compiling-opencv-with-cuda-support/)
+

--- a/build-gpu-libs.md
+++ b/build-gpu-libs.md
@@ -108,6 +108,8 @@ cd gpu
 python setup.py build_ext --inplace
 ```
 
+**Note: if you're using different opencv directory, please modify it in `setup.py` (search `write_cmakelist` as keyword) before building.**
+
 Finally, use the compiled OpenCV Python lib and GpuWrapper lib together, i.e. in `math_utils.py`, modify the imports to be like this:
 ```Python
 import sys
@@ -199,6 +201,8 @@ Then do:
 cd libs/gpu
 python setup.py build_ext --inplace
 ```
+
+**Note: if you're using different opencv directory, please modify it in `setup.py` (search `write_cmakelist` as keyword) before building.**
 
 Then use this built opencv2 python library and GpuWrapper together, such as in `math_utils.py`. Modify its imports like in the windows example.
 

--- a/libs/gpu/pyopencv_converter.cpp
+++ b/libs/gpu/pyopencv_converter.cpp
@@ -104,7 +104,9 @@ public:
         {
             CV_Error(Error::StsAssert, "The data should normally be NULL!");
             // probably this is safe to do in such extreme case
-            return stdAllocator->allocate(dims0, sizes, type, data, step, flags, usageFlags);
+            return stdAllocator->allocate(dims0, sizes, type, data, step, 
+                cv::AccessFlag(flags), usageFlags
+            );
         }
         PyEnsureGIL gil;
 
@@ -129,7 +131,9 @@ public:
 
     bool allocate(UMatData* u, int accessFlags, UMatUsageFlags usageFlags) const
     {
-        return stdAllocator->allocate(u, accessFlags, usageFlags);
+        return stdAllocator->allocate(u, 
+            cv::AccessFlag(accessFlags), usageFlags
+        );
     }
 
     void deallocate(UMatData* u) const

--- a/libs/gpu/pyopencv_converter.cpp
+++ b/libs/gpu/pyopencv_converter.cpp
@@ -104,9 +104,7 @@ public:
         {
             CV_Error(Error::StsAssert, "The data should normally be NULL!");
             // probably this is safe to do in such extreme case
-            return stdAllocator->allocate(dims0, sizes, type, data, step, 
-                cv::AccessFlag(flags), usageFlags
-            );
+            return stdAllocator->allocate(dims0, sizes, type, data, step, flags, usageFlags);
         }
         PyEnsureGIL gil;
 
@@ -131,9 +129,7 @@ public:
 
     bool allocate(UMatData* u, int accessFlags, UMatUsageFlags usageFlags) const
     {
-        return stdAllocator->allocate(u, 
-            cv::AccessFlag(accessFlags), usageFlags
-        );
+        return stdAllocator->allocate(u, accessFlags, usageFlags);
     }
 
     void deallocate(UMatData* u) const

--- a/libs/gpu/setup-old.py
+++ b/libs/gpu/setup-old.py
@@ -1,0 +1,36 @@
+import subprocess
+import os
+import numpy as np
+from distutils.core import setup, Extension
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
+
+"""
+Run setup with the following command:
+```
+python setupGpuWrapper.py build_ext --inplace
+```
+"""
+
+# Determine current directory of this setup file to find our module
+CUR_DIR = os.path.dirname(__file__)
+# Use pkg-config to determine library locations and include locations
+opencv_libs_str = subprocess.check_output("pkg-config --libs opencv".split()).decode()
+opencv_incs_str = subprocess.check_output("pkg-config --cflags opencv".split()).decode()
+# Parse into usable format for Extension call
+opencv_libs = [str(lib) for lib in opencv_libs_str.strip().split()]
+opencv_incs = [str(inc) for inc in opencv_incs_str.strip().split()]
+
+extensions = [
+    Extension('GpuWrapper',
+              sources=[os.path.join(CUR_DIR, 'GpuWrapper.pyx')],
+              language='c++',
+              include_dirs=[np.get_include()] + opencv_incs,
+              extra_link_args=opencv_libs)
+]
+
+setup(
+    cmdclass={'build_ext': build_ext},
+    name="GpuWrapper",
+    ext_modules=cythonize(extensions)
+)

--- a/libs/gpu/setup.py
+++ b/libs/gpu/setup.py
@@ -42,6 +42,7 @@ def write_cmakelist(opencv_install_dir):
     lines.append('set(CMAKE_CXX_STANDARD 11)')
     lines.append('set(OpenCV_DIR "{:s}" CACHE PATH "")'.format(opencv_install_dir))
     lines.append('find_package(OpenCV)')
+    lines.append('set(MYDEP_VERSION_STR "${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH}" CACHE STRING "")')
     lines.append('set(MYDEP_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS} CACHE PATH "")')
     lines.append('set(MYDEP_LIBS ${OpenCV_LIBS} CACHE PATH "")')
 
@@ -61,7 +62,7 @@ assert cmake, 'Could not find "cmake" executable!'
 
 # You may modify me here!
 if platform.system()=='Windows':
-    write_cmakelist("D:/work/opencv-4.3.0/build/vs2017-x64-gpu/install")
+    write_cmakelist("D:/lib/opencv/3.4.11")
 else:
     write_cmakelist("/home/zz/soft/opencv-3.4.11/share/OpenCV")
 
@@ -74,10 +75,12 @@ with cd(CMAKE_BUILD_DIR):
         '-DBUILD_SHARED_LIBS=OFF',
         '-DCMAKE_BUILD_TYPE=Release'
     ]
+    print('----- platform.system()=', platform.system())
     if(platform.system()=='Windows'):
         cmake_args.append('-G')
         cmake_args.append('Visual Studio 15 2017 Win64')
     cmake_args.append(TOP_DIR)
+    print('----- cmake commands:', cmake_args)
     subprocess.check_call(cmake_args)
 
 cmake_cache_file = os.path.join(CMAKE_BUILD_DIR, 'CMakeCache.txt')
@@ -101,6 +104,10 @@ for line in fin.readlines():
         mydep_library_dirs = [line.split('=')[1]]
     if line.startswith('MYDEP_LIBS'):
         mydep_libs = line.split('=')[1].split(';')
+    if line.startswith('MYDEP_VERSION'):
+        mydep_version = line.split('=')[1]
+if platform.system()=='Windows':
+    mydep_libs = [_+mydep_version for _ in mydep_libs]
 fin.close()
 
 
@@ -125,7 +132,8 @@ extensions = [
               libraries=mydep_libs,
               library_dirs=mydep_library_dirs,
               define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
-              extra_link_args=['-v'])
+              #extra_link_args=['-v']
+              )
 ]
 
 setup(

--- a/libs/gpu/setup.py
+++ b/libs/gpu/setup.py
@@ -5,6 +5,11 @@ from distutils.core import setup, Extension
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 
+from distutils.spawn import find_executable
+import sys
+from distutils import sysconfig, log
+from contextlib import contextmanager
+
 """
 Run setup with the following command:
 ```
@@ -12,21 +17,108 @@ python setupGpuWrapper.py build_ext --inplace
 ```
 """
 
+@contextmanager
+def cd(path):
+    if not os.path.isabs(path):
+        raise RuntimeError('Can only cd to absolute path, got: {}'.format(path))
+    if os.path.isdir(path) is False:
+        os.makedirs(path)
+    orig_path = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(orig_path)
+
+
+def write_cmakelist(opencv_install_dir):
+    """
+    @param opencv_install_dir: the directory that contains 'OpenCVConfig.cmake'
+    """
+    lines = []
+    lines.append('cmake_minimum_required(VERSION 3.6)')
+    lines.append('project(qq)')
+    lines.append('set(CMAKE_CXX_STANDARD 11)')
+    lines.append('set(OpenCV_DIR "{:s}" CACHE PATH "")'.format(opencv_install_dir))
+    lines.append('find_package(OpenCV)')
+    lines.append('set(MYDEP_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS} CACHE PATH "")')
+    lines.append('set(MYDEP_LIBS ${OpenCV_LIBS} CACHE PATH "")')
+    lines.append('set(MYDEP_LIBRARY_DIRS "${OpenCV_DIR}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib" CACHE PATH "")')
+
+    fout = open('CMakeLists.txt', 'w', encoding='utf-8')
+    for line in lines:
+        fout.write(line+"\n")
+    fout.close()
+
+
+cmake = find_executable('cmake')
+assert cmake, 'Could not find "cmake" executable!'
+
+# You may modify me here!
+write_cmakelist("D:/work/opencv-4.3.0/build/vs2017-x64-gpu/install")
+
+TOP_DIR = os.path.realpath(os.path.dirname(__file__))
+CMAKE_BUILD_DIR = os.path.join(TOP_DIR, '.setuptools-cmake-build')
+
+with cd(CMAKE_BUILD_DIR):
+    cmake_args = [
+        cmake,
+        '-DBUILD_SHARED_LIBS=OFF',
+        '-DPYTHON_EXECUTABLE:FILEPATH={}'.format(sys.executable),
+        '-DPYTHON_INCLUDE_DIR={}'.format(sysconfig.get_python_inc()),
+        '-DBUILD_TEST=OFF',
+        '-DBUILD_BENCHMARK=OFF',
+        '-DBUILD_BINARY=OFF',
+        '-G', 'Visual Studio 15 2017 Win64'
+    ]
+    cmake_args.append(TOP_DIR)
+    subprocess.check_call(cmake_args)
+
+cmake_cache_file = os.path.join(CMAKE_BUILD_DIR, 'CMakeCache.txt')
+
+"""
+for example:
+
+MYDEP_INCLUDE_DIRS:PATH=D:/work/opencv-4.3.0/build/vs2017-x64-gpu/install/include
+
+MYDEP_LIBRARY_DIRS:PATH=D:/work/opencv-4.3.0/build/vs2017-x64-gpu/install/x64/vc15/lib
+
+MYDEP_LIBS:PATH=opencv_calib3d;opencv_core;opencv_features2d;opencv_flann;opencv_gapi;opencv_highgui;opencv_imgcodecs;opencv_imgproc;opencv_ml;opencv_objdetect;opencv_photo;opencv_stitching;opencv_video;opencv_videoio;opencv_aruco;opencv_bgsegm;opencv_bioinspired;opencv_ccalib;opencv_cudaarithm;opencv_cudabgsegm;opencv_cudacodec;opencv_cudafeatures2d;opencv_cudafilters;opencv_cudaimgproc;opencv_cudalegacy;opencv_cudaobjdetect;opencv_cudaoptflow;opencv_cudastereo;opencv_cudawarping;opencv_cudev;opencv_datasets;opencv_dpm;opencv_face;opencv_fuzzy;opencv_hfs;opencv_img_hash;opencv_intensity_transform;opencv_line_descriptor;opencv_optflow;opencv_phase_unwrapping;opencv_plot;opencv_quality;opencv_rapid;opencv_reg;opencv_rgbd;opencv_saliency;opencv_shape;opencv_stereo;opencv_structured_light;opencv_superres;opencv_surface_matching;opencv_tracking;opencv_videostab;opencv_xfeatures2d;opencv_ximgproc;opencv_xobjdetect;opencv_xphoto
+"""
+
+fin = open(cmake_cache_file, 'r')
+for line in fin.readlines():
+    line = line.strip()
+    if line.startswith('MYDEP_INCLUDE_DIRS'):
+        mydep_include_dirs = [line.split('=')[1]]
+    if line.startswith('MYDEP_LIBRARY_DIRS'):
+        mydep_library_dirs = [line.split('=')[1]]
+    if line.startswith('MYDEP_LIBS'):
+        mydep_libs = [line.split('=')[1]]
+fin.close()
+
+
+
 # Determine current directory of this setup file to find our module
 CUR_DIR = os.path.dirname(__file__)
 # Use pkg-config to determine library locations and include locations
-opencv_libs_str = subprocess.check_output("pkg-config --libs opencv".split()).decode()
-opencv_incs_str = subprocess.check_output("pkg-config --cflags opencv".split()).decode()
+#opencv_libs_str = subprocess.check_output("pkg-config --libs opencv".split()).decode()
+#opencv_incs_str = subprocess.check_output("pkg-config --cflags opencv".split()).decode()
+
 # Parse into usable format for Extension call
-opencv_libs = [str(lib) for lib in opencv_libs_str.strip().split()]
-opencv_incs = [str(inc) for inc in opencv_incs_str.strip().split()]
+#opencv_libs = [str(lib) for lib in opencv_libs_str.strip().split()]
+#opencv_incs = [str(inc) for inc in opencv_incs_str.strip().split()]
 
 extensions = [
     Extension('GpuWrapper',
               sources=[os.path.join(CUR_DIR, 'GpuWrapper.pyx')],
               language='c++',
-              include_dirs=[np.get_include()] + opencv_incs,
-              extra_link_args=opencv_libs)
+              include_dirs=[np.get_include()] + mydep_include_dirs,
+              libraries=mydep_libs,
+              library_dirs=mydep_library_dirs,
+              #define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+              )
+              #extra_link_args=opencv_libs)
 ]
 
 setup(


### PR DESCRIPTION
The previous GPU related building is not working on Windows. There's no pkg-config for OpenCV on Windows.

I do these change:
- Replace `pkg-config` based opencv config with `cmake` based, which is simply implemented in `setup.py`
- Support both Linux/Mac & Windows, i.e. G++/Clang++ for Linux/Mac, Visual Studio for Windows
- Give precise steps to take for building, in `build-gpu-libs.md`

Hope these changes help Windows users.
